### PR TITLE
Remove manual register of `<style>` element

### DIFF
--- a/components/layout.rb
+++ b/components/layout.rb
@@ -2,8 +2,6 @@
 
 module Components
 	class Layout < Phlex::HTML
-		register_element :style
-
 		def initialize(title:)
 			@title = title
 		end
@@ -30,7 +28,7 @@ module Components
 
 					title { @title }
 					link href: "/application.css", rel: "stylesheet"
-					style { unsafe_raw Rouge::Theme.find("github").render(scope: ".highlight") }
+					style { Rouge::Theme.find("github").render(scope: ".highlight") }
 				end
 
 				body class: "text-stone-700" do


### PR DESCRIPTION
This pull request removes the manual register of the `<style>` element in `components/layout.rb`

`phlex` now also supports `<style>` elements since they were added in `0.2.0` via https://github.com/joeldrapper/phlex/pull/123

I guess with the introduction of https://github.com/joeldrapper/phlex/pull/449 this now started failing with:

```bash
phlex/lib/phlex/html.rb:444:in `method_added': 👋 Redefining the method `Components::Layout#_style` is not a good idea. (Phlex::NameError)
from phlex/lib/phlex/elements.rb:35:in `alias_method'
from phlex/lib/phlex/elements.rb:35:in `register_element'
from phlex/lib/phlex/elements.rb:10:in `class_eval'
from phlex/lib/phlex/elements.rb:10:in `register_element'
from phlex.fun/components/layout.rb:5:in `<class:Layout>'
from phlex.fun/components/layout.rb:4:in `<module:Components>'
from phlex.fun/components/layout.rb:3:in `<top (required)>'
```