### PR TITLE
Update assertion in Capybara testing docs

### DIFF
--- a/pages/testing/capybara.md
+++ b/pages/testing/capybara.md
@@ -30,7 +30,7 @@ example do |e|
 
       def test_example
         render Example.new("Joel")
-        assert_select "h1", text: "Hello Joel"
+        assert_selector "h1", text: "Hello Joel"
       end
     end
   RUBY


### PR DESCRIPTION
Fixes what I believe to be a typo. [`assert_select`](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara%2FMinitest%2FAssertions:assert_select) checks if the page or current node has a `<select>` field with the given label, name or id, while [`assert_selector`](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#assert_selector-instance_method) asserts that a given selector is present.