### PR TITLE
Minor documentation corrections

### DIFF
--- a/pages/html/helpers.md
+++ b/pages/html/helpers.md
@@ -6,7 +6,7 @@ title: HTML view helpers
 
 ## Stand-alone text
 
-You can output text content without wrapping it in an element by using the `text` method. It accepts a single argument which can be a `String`, `Symbol`, `Integer` or `Float`.
+You can output text content without wrapping it in an element by using the `plain` method. It accepts a single argument which can be a `String`, `Symbol`, `Integer` or `Float`.
 
 ```phlex
 example do |e|
@@ -15,7 +15,7 @@ example do |e|
 			def template
 				h1 do
 					strong { "Hello " }
-					text "World!"
+					plain "World!"
 				end
 			end
 		end

--- a/pages/rails/rendering_views.md
+++ b/pages/rails/rendering_views.md
@@ -13,13 +13,13 @@ class ArticlesController < ApplicationController
 	layout -> { ApplicationLayout }
 	
   def index
-    render Views::Articles::Index.new(
+    render Articles::IndexView.new(
       articles: Article.all.load_async
     )
   end
 
   def show
-    render Views::Articles::Show.new(
+    render Articles::ShowView.new(
       article: Article.find(params[:id])
     )
   end


### PR DESCRIPTION
This PR fixes two minor issues:
1. When using generators to create new views, they are created as `Articles::IndexView`. However the section about rendering views have them namespaced under views (`Views::Articles::Index`).
2. The `text` method has been deprecated, but the documentation still refers to it.