### PR TITLE
Fix instructions for Rails legacy layouts to use Proc instead of block

### DIFF
--- a/rails/layouts.md
+++ b/rails/layouts.md
@@ -249,11 +249,11 @@ class Components::Layout < Components::Base
 end
 ```
 
-In the controller, you need to specify the layout with a block like this.
+In the controller, you need to specify the layout with a Proc like this.
 
 ```ruby
 class ArticlesController
-  layout { Components::Layout }
+  layout -> { Components::Layout }
 end
 ```
 


### PR DESCRIPTION
This seems like a typo. `layout` doesn't appear to take a block. No mention of it in the Rails docs/source and attempting it on Rails 8.0.2 raises an `ArgumentError` with "expected 1..2".  