### PR TITLE
docs: add usage note for path() and raw() in SVG's

### DIFF
--- a/sgml/svg-elements.md
+++ b/sgml/svg-elements.md
@@ -4,6 +4,28 @@ title: SVG elements DSL in Phlex
 
 # SVG elements
 
+> **Note:**  
+> You can call these SVG methods (like `path()`, `circle()`, etc.) inside a class that extends `Phlex::HTML` (or `Phlexicons`).  
+> For example:
+>
+> ```ruby
+> class MyIcon < PhlexIcons
+>   def template
+>     svg(xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 24 24") do
+>       path(d: "M12 2L2 22h20L12 2z")
+>     end
+>   end
+> end
+> ```
+>
+> If you need to embed raw SVG markup directly, you can also use:
+>
+> ```ruby
+> raw("<path d='M12 2L2 22h20L12 2z'>".html_safe)
+> ```
+
+---
+
 ## `a`
 
 Renders an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/a) element.

--- a/sgml/svg-elements.md
+++ b/sgml/svg-elements.md
@@ -21,7 +21,7 @@ title: SVG elements DSL in Phlex
 > If you need to embed raw SVG markup directly, you can also use:
 >
 > ```ruby
-> raw("<path d='M12 2L2 22h20L12 2z'>".html_safe)
+> raw safe("<path d='M12 2L2 22h20L12 2z'>")
 > ```
 
 ---


### PR DESCRIPTION
Added a note at the top of the SVG elements DSL documentation to clarify usage:

- Showed that `path()` and other SVG methods can be used inside a class extending `PhlexIcons`.
- Added example of embedding raw SVG markup with `raw("...".html_safe)`.
- Helps developers understand how to integrate SVG elements directly in their PhlexIcons components.